### PR TITLE
Remove unecessary circleci filter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -244,8 +244,6 @@ workflows:
           filters:
             tags:
               only: /^build-wheel.*/
-            branches:
-              ignore: /^gh-pages/
       #Build the wheels if commit tag starts with build-wheel
       - build-linux-wheel:
           requires:


### PR DESCRIPTION
ignoring ```gh-pages``` was fixed by adding empty circle ci config in branch