### PR TITLE
Solving Physics Puzzles by Reasoning about Paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ If you use PHYRE in your experiments, please cite it:
 
 # Related projects
 
+[Solving Physics Puzzles by Reasoning about Paths](https://github.com/ndrwmlnk/PHYRE-Reasoning-about-Paths) is a new deep learning model for goal-driven tasks that require intuitive physical reasoning and intervention in the scene to achieve a desired end goal ([NeurIPS video presentation](https://youtu.be/X30QGeIEXRs);  [arXiv:2011.07357](https://arxiv.org/abs/2011.07357)).
+
 [Virtual Tools](https://k-r-allen.github.io/tool-games/) is a similar project aiming to research the structure necessary to capture human-like reasoning in these sorts of physics puzzles.
 
 [ESPRIT](https://blog.einstein.ai/explaining-solutions-to-physical-reasoning-tasks/) is a framework based on PHYRE that connects physical reasoning and natural language explanations.


### PR DESCRIPTION
Hi,

this is our new paper/model based on PHYRE accepted at the NeurIPS 2020 workshop on Interpretable Inductive Biases and Physically Structured Learning. Would it be possible to add it to the "Related projects" in the README.md file?

https://arxiv.org/abs/2011.07357
https://youtu.be/X30QGeIEXRs
https://github.com/ndrwmlnk/PHYRE-Reasoning-about-Paths

Thanks!